### PR TITLE
1.19に対応

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "numalauncher",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "numalauncher",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "license": "UNLICENSED",
             "dependencies": {
                 "adm-zip": "^0.5.1",
@@ -35,7 +35,7 @@
             },
             "devDependencies": {
                 "cross-env": "^7.0.3",
-                "electron": "^13.1.8",
+                "electron": "^13.6.9",
                 "electron-builder": "^22.11.7",
                 "eslint": "^7.15.0"
             },
@@ -863,6 +863,15 @@
             "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
             "dependencies": {
                 "tweetnacl": "^0.14.3"
+            }
+        },
+        "node_modules/bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "peer": true,
+            "dependencies": {
+                "file-uri-to-path": "1.0.0"
             }
         },
         "node_modules/bl": {
@@ -2421,6 +2430,12 @@
                 "node": "^10.12.0 || >=12.0.0"
             }
         },
+        "node_modules/file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "peer": true
+        },
         "node_modules/filelist": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
@@ -3635,9 +3650,7 @@
         "node_modules/node-addon-api": {
             "version": "1.7.2",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-            "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
-            "dev": true,
-            "optional": true
+            "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
         },
         "node_modules/node-fetch": {
             "version": "2.6.7",
@@ -3965,6 +3978,17 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/mysticatea"
+            }
+        },
+        "node_modules/register-scheme": {
+            "version": "0.0.2",
+            "resolved": "git+ssh://git@github.com/devsnek/node-register-scheme.git#e7cc9a63a1f512565da44cb57316d9fb10750e17",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "bindings": "^1.3.0",
+                "node-addon-api": "^1.3.0"
             }
         },
         "node_modules/registry-auth-token": {
@@ -5894,6 +5918,15 @@
                 "tweetnacl": "^0.14.3"
             }
         },
+        "bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "peer": true,
+            "requires": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
         "bl": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -7135,6 +7168,12 @@
                 "flat-cache": "^3.0.4"
             }
         },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "peer": true
+        },
         "filelist": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
@@ -8051,9 +8090,7 @@
         "node-addon-api": {
             "version": "1.7.2",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-            "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
-            "dev": true,
-            "optional": true
+            "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
         },
         "node-fetch": {
             "version": "2.6.7",
@@ -8300,6 +8337,15 @@
             "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
             "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
             "dev": true
+        },
+        "register-scheme": {
+            "version": "git+ssh://git@github.com/devsnek/node-register-scheme.git#e7cc9a63a1f512565da44cb57316d9fb10750e17",
+            "from": "register-scheme@github:devsnek/node-register-scheme",
+            "peer": true,
+            "requires": {
+                "bindings": "^1.3.0",
+                "node-addon-api": "^1.3.0"
+            }
         },
         "registry-auth-token": {
             "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     },
     "devDependencies": {
         "cross-env": "^7.0.3",
-        "electron": "^13.1.8",
+        "electron": "^13.6.9",
         "electron-builder": "^22.11.7",
         "eslint": "^7.15.0"
     },


### PR DESCRIPTION
沼ランv3.1.0にMinecraftのバージョン1.19が起動しない不具合があったので、直しました。

参考：https://github.com/dscalzi/HeliosLauncher/pull/261/commits/8e76d6a2b9d7dcfc64f8b85e9770dc551b0cb43f